### PR TITLE
hotfix: correction conversion UTC vers fuseau local

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -471,7 +471,10 @@
 		
 		if (dateStr === today) return `${fireEmoji}Aujourd'hui`;
 		if (dateStr === yesterday) return `${fireEmoji}Hier, ${formatDate(dateStr)}`;
-		const date = new Date(dateStr);
+		// Forcer l'interprétation UTC en ajoutant 'Z' si pas de timezone
+		const date = dateStr.includes('T') || dateStr.includes('Z')
+			? new Date(dateStr)
+			: new Date(dateStr.replace(' ', 'T') + 'Z');
 		const formattedDate = date.toLocaleDateString('fr-FR', { weekday: 'long', day: 'numeric', month: 'long' });
 		return `${fireEmoji}${formattedDate.charAt(0).toUpperCase()}${formattedDate.slice(1)}`;
 	}
@@ -487,7 +490,11 @@
 	}
 
 	function formatDate(dateStr: string): string {
-		const date = new Date(dateStr);
+		// Forcer l'interprétation UTC en ajoutant 'Z' si pas de timezone
+		const date = dateStr.includes('T') || dateStr.includes('Z')
+			? new Date(dateStr)
+			: new Date(dateStr.replace(' ', 'T') + 'Z');
+		
 		return date.toLocaleDateString('fr-FR', { weekday: 'long', day: 'numeric', month: 'long' });
 	}
 
@@ -498,7 +505,11 @@
 	}
 
 	function formatTime(dateStr: string): string {
-		const date = new Date(dateStr);
+		// Forcer l'interprétation UTC en ajoutant 'Z' si pas de timezone
+		const date = dateStr.includes('T') || dateStr.includes('Z')
+			? new Date(dateStr)
+			: new Date(dateStr.replace(' ', 'T') + 'Z');
+		
 		const timezone = data.user?.timezone || 'Europe/Paris';
 		const formatter = new Intl.DateTimeFormat('fr-FR', {
 			hour: '2-digit',


### PR DESCRIPTION
## Problème
Les dates stockées en UTC (format 'YYYY-MM-DD HH:MM:SS') étaient interprétées comme heure locale au lieu d'UTC, causant un décalage de 2h dans l'affichage.

## Solution
Modification des fonctions de formatage pour ajouter 'Z' (indicateur UTC) aux dates sans timezone :
- formatTime() : Affichage des heures
- formatDate() : Affichage des dates  
- formatDateHeader() : En-têtes de date

## Changements
- Force l'interprétation UTC en ajoutant 'Z' si pas de timezone dans la chaîne
- Conversion correcte vers le fuseau horaire de l'utilisateur

## Tests
- [ ] Anciennes capsules affichent la bonne heure
- [ ] Nouvelles capsules créées affichent l'heure correcte
- [ ] Pas de décalage de 2h

**Note** : Nécessite que la migration timezone ait déjà été appliquée en production.