### PR TITLE
fix: validate timezone before saving to prevent runtime errors

### DIFF
--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -606,6 +606,12 @@ export function updateUserAvatar(userId: number, avatar: string): void {
 }
 
 export function updateUserTimezone(userId: number, timezone: string): void {
+	// Valider que le timezone est reconnu par le moteur JavaScript
+	try {
+		Intl.DateTimeFormat(undefined, { timeZone: timezone });
+	} catch {
+		return; // Timezone invalide, on ne met pas à jour
+	}
 	const stmt = db.prepare('UPDATE users SET timezone = ? WHERE id = ?');
 	stmt.run(timezone, userId);
 }


### PR DESCRIPTION
## Résumé
- Ajout d'une validation du timezone dans `updateUserTimezone` avant l'écriture en base de données.

## Problème
La fonction `updateUserTimezone` dans `src/lib/server/db.ts` enregistrait directement la valeur du timezone en base sans aucune vérification. Si un timezone invalide était sauvegardé, tous les appels ultérieurs à `Intl.DateTimeFormat` (dans `getDateInTimezone`, `getDateWithThreshold`, `isDateAvailable`, etc.) déclenchaient un `RangeError` non intercepté, ce qui pouvait crasher l'application pour l'utilisateur concerné.

## Solution
On utilise `Intl.DateTimeFormat(undefined, { timeZone: timezone })` dans un bloc `try/catch` pour vérifier que le timezone est reconnu par le moteur JavaScript avant de l'enregistrer en base. Si la valeur est invalide, la mise à jour est simplement ignorée, ce qui protège l'application sans impact pour l'utilisateur.

## Test plan
- Vérifier qu'un timezone valide (ex: `Europe/Paris`, `America/New_York`) est bien enregistré en base.
- Vérifier qu'un timezone invalide (ex: `Fake/Zone`, `abc123`) est rejeté silencieusement et que la valeur en base reste inchangée.
- Vérifier que les fonctions en aval (`getDateInTimezone`, etc.) continuent de fonctionner normalement après la mise à jour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)