### PR TITLE
fix: add periodic cleanup for expired sessions, CSRF tokens and login attempts

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,8 +1,11 @@
 import type { Handle } from '@sveltejs/kit';
-import { getSession, hasAdmin, refreshSession, generateCSRFToken, validateCSRFToken } from '$lib/server/db';
+import { getSession, hasAdmin, refreshSession, generateCSRFToken, validateCSRFToken, periodicCleanup } from '$lib/server/db';
 
 export const handle: Handle = async ({ event, resolve }) => {
 	const sessionId = event.cookies.get('session');
+
+	// Nettoyage périodique des données expirées
+	periodicCleanup();
 
 	if (sessionId) {
 		const user = getSession(sessionId);

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -688,6 +688,11 @@ export function deleteSession(sessionId: string): void {
 	stmt.run(sessionId);
 }
 
+export function cleanupExpiredSessions(): void {
+	const stmt = db.prepare("DELETE FROM sessions WHERE expires_at < datetime('now')");
+	stmt.run();
+}
+
 export function saveRecording(userId: number, audioData: Buffer, durationSeconds: number, imageData?: Buffer, url?: string | null, audioHash?: string): Recording {
 	debug.db.log('saveRecording - audioData:', audioData.length, 'bytes, imageData:', imageData?.length || 'none');
 	
@@ -942,6 +947,19 @@ export function consumeCSRFToken(token: string): void {
 export function cleanupExpiredCSRF(): void {
 	const stmt = db.prepare('DELETE FROM csrf_tokens WHERE expires_at < datetime(\'now\')');
 	stmt.run();
+}
+
+let lastCleanup = 0;
+const CLEANUP_INTERVAL = 60 * 60 * 1000; // 1 heure
+
+export function periodicCleanup(): void {
+	const now = Date.now();
+	if (now - lastCleanup < CLEANUP_INTERVAL) return;
+	lastCleanup = now;
+
+	cleanupExpiredSessions();
+	cleanupExpiredCSRF();
+	cleanupOldLoginAttempts();
 }
 
 // ============ REGISTRATION MANAGEMENT FUNCTIONS ============


### PR DESCRIPTION
## Résumé
- Ajout d'une fonction `cleanupExpiredSessions()` pour supprimer les sessions expirées
- Ajout d'une fonction unifiée `periodicCleanup()` qui regroupe le nettoyage des sessions, tokens CSRF et tentatives de connexion
- Appel automatique du nettoyage dans le hook serveur, avec un intervalle d'une heure entre chaque exécution

## Problème
Les tables `sessions`, `csrf_tokens` et `login_attempts` grossissent indéfiniment car les données expirées ne sont jamais supprimées. Les fonctions `cleanupOldLoginAttempts()` et `cleanupExpiredCSRF()` existaient déjà dans `db.ts` mais n'étaient appelées nulle part. De plus, il n'existait aucune fonction pour nettoyer les sessions expirées.

## Solution
1. Ajout de `cleanupExpiredSessions()` juste après `deleteSession()` dans `db.ts`
2. Ajout de `periodicCleanup()` qui orchestre les trois fonctions de nettoyage avec un garde-fou temporel (maximum une exécution par heure) pour ne pas impacter les performances
3. Appel de `periodicCleanup()` au début du hook `handle` dans `hooks.server.ts`, de sorte que le nettoyage se fait naturellement au fil des requêtes sans nécessiter de cron externe

## Test plan
- [ ] Vérifier que l'application démarre sans erreur
- [ ] Vérifier que le premier appel à `periodicCleanup()` exécute bien le nettoyage
- [ ] Vérifier que les appels suivants dans la même heure sont ignorés (pas d'impact sur les performances)
- [ ] Vérifier que les sessions expirées, tokens CSRF expirés et tentatives de connexion anciennes sont bien supprimés

🤖 Generated with [Claude Code](https://claude.com/claude-code)