### PR TITLE
fix(perf): read only 4 bytes for magic number detection instead of entire file

### DIFF
--- a/src/routes/uploads/[...file]/+server.ts
+++ b/src/routes/uploads/[...file]/+server.ts
@@ -1,6 +1,5 @@
 import type { RequestHandler } from './$types';
-import { createReadStream, statSync, readFileSync, existsSync } from 'fs';
-import type { ObjectEncodingOptions } from 'fs';
+import { createReadStream, statSync, openSync, readSync, closeSync, existsSync } from 'fs';
 import { join, normalize } from 'path';
 import { redirect } from '@sveltejs/kit';
 import { Readable } from 'stream';
@@ -30,17 +29,22 @@ export const GET: RequestHandler = async ({ params, locals }) => {
 		const ext = normalizedPath.split('.').pop()?.toLowerCase();
 		let contentType = getContentType(ext);
 		
-		// Détection du format réel par magic numbers (seulement les premiers bytes)
-		const headerBuffer = readFileSync(normalizedPath, { start: 0, end: 3 } as ObjectEncodingOptions & { flag?: string });
-		if (headerBuffer.length > 0) {
-			const isPNG = headerBuffer[0] === 0x89 && headerBuffer[1] === 0x50 && headerBuffer[2] === 0x4E && headerBuffer[3] === 0x47;
-			const isJPEG = headerBuffer[0] === 0xFF && headerBuffer[1] === 0xD8 && headerBuffer[2] === 0xFF;
-			
-			if (isPNG && contentType !== 'image/png') {
-				contentType = 'image/png';
-			} else if (isJPEG && contentType !== 'image/jpeg') {
-				contentType = 'image/jpeg';
-			}
+		// Détection du format réel par magic numbers (4 premiers octets uniquement)
+		const headerBuffer = Buffer.alloc(4);
+		const fd = openSync(normalizedPath, 'r');
+		try {
+			readSync(fd, headerBuffer, 0, 4, 0);
+		} finally {
+			closeSync(fd);
+		}
+
+		const isPNG = headerBuffer[0] === 0x89 && headerBuffer[1] === 0x50 && headerBuffer[2] === 0x4E && headerBuffer[3] === 0x47;
+		const isJPEG = headerBuffer[0] === 0xFF && headerBuffer[1] === 0xD8 && headerBuffer[2] === 0xFF;
+
+		if (isPNG && contentType !== 'image/png') {
+			contentType = 'image/png';
+		} else if (isJPEG && contentType !== 'image/jpeg') {
+			contentType = 'image/jpeg';
 		}
 
 		return new Response(Readable.toWeb(createReadStream(normalizedPath)) as unknown as ReadableStream<Uint8Array>, {


### PR DESCRIPTION
## Résumé
- Remplacement de `readFileSync` par `openSync`/`readSync`/`closeSync` pour ne lire que 4 octets lors de la détection des magic numbers dans le endpoint uploads.

## Problème
Le code utilisait `readFileSync` avec des options `{ start: 0, end: 3 }` pour lire les premiers octets d'un fichier et détecter son type MIME réel via les magic numbers (PNG, JPEG). Or, `readFileSync` **n'accepte pas** les options `start`/`end` -- seul `createReadStream` les supporte. Le cast `as ObjectEncodingOptions & { flag?: string }` masquait l'erreur au compilateur TypeScript, mais en pratique, **le fichier entier était lu en mémoire** juste pour vérifier 4 octets. Pour un fichier audio de 20 Mo, cela signifiait 20 Mo chargés en RAM puis immédiatement ignorés, avant de re-streamer le fichier via `createReadStream`.

## Solution
Utilisation de l'API bas niveau de Node.js (`openSync`, `readSync`, `closeSync`) qui permet de lire exactement les 4 octets nécessaires, avec un `try/finally` pour garantir la fermeture du file descriptor. L'import inutile de `ObjectEncodingOptions` a également été supprimé.

Les changements sont minimes et ciblés :
- Import : `readFileSync` remplacé par `openSync`, `readSync`, `closeSync`
- Suppression de l'import `ObjectEncodingOptions` devenu inutile
- Bloc de détection réécrit pour lire uniquement 4 octets

## Test plan
- [ ] Vérifier qu'un fichier PNG uploadé est servi avec le bon Content-Type `image/png`
- [ ] Vérifier qu'un fichier JPEG uploadé est servi avec le bon Content-Type `image/jpeg`
- [ ] Vérifier qu'un fichier audio (.m4a, .webm) est servi correctement sans régression
- [ ] Vérifier qu'un fichier inexistant retourne bien une 404
- [ ] Vérifier qu'un utilisateur non authentifié est redirigé vers /login

🤖 Generated with [Claude Code](https://claude.com/claude-code)