### PR TITLE
fix(security): invalidate sessions on password change

### DIFF
--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -688,6 +688,16 @@ export function deleteSession(sessionId: string): void {
 	stmt.run(sessionId);
 }
 
+export function deleteUserSessions(userId: number, exceptSessionId?: string): void {
+	if (exceptSessionId) {
+		const stmt = db.prepare('DELETE FROM sessions WHERE user_id = ? AND id != ?');
+		stmt.run(userId, exceptSessionId);
+	} else {
+		const stmt = db.prepare('DELETE FROM sessions WHERE user_id = ?');
+		stmt.run(userId);
+	}
+}
+
 export function saveRecording(userId: number, audioData: Buffer, durationSeconds: number, imageData?: Buffer, url?: string | null, audioHash?: string): Recording {
 	debug.db.log('saveRecording - audioData:', audioData.length, 'bytes, imageData:', imageData?.length || 'none');
 	

--- a/src/routes/settings/+page.server.ts
+++ b/src/routes/settings/+page.server.ts
@@ -1,7 +1,7 @@
 import type { PageServerLoad, Actions } from './$types';
 import { redirect, fail } from '@sveltejs/kit';
 import { hashSync } from 'bcrypt';
-import { updateUserAvatar, updateUserHour, updateUserTimezone, getUserById, updateUserPassword, updateUserPseudo, isPseudoAvailable } from '$lib/server/db';
+import { updateUserAvatar, updateUserHour, updateUserTimezone, getUserById, updateUserPassword, updateUserPseudo, isPseudoAvailable, deleteUserSessions } from '$lib/server/db';
 import { readdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import { version } from '../../../package.json';
@@ -70,7 +70,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 };
 
 	export const actions: Actions = {
-	default: async ({ request, locals }) => {
+	default: async ({ request, locals, cookies }) => {
 		const data = await request.formData();
 		const avatar = data.get('avatar')?.toString() || '☕';
 		const avatarImage = data.get('avatarImage')?.toString();
@@ -143,6 +143,12 @@ export const load: PageServerLoad = async ({ locals }) => {
 				}
 				const hashedPassword = hashSync(password, 10);
 				updateUserPassword(locals.user.id, hashedPassword);
+
+				// Invalider toutes les autres sessions (sécurité)
+				const sessionId = cookies.get('session');
+				if (sessionId) {
+					deleteUserSessions(locals.user.id, sessionId);
+				}
 			}
 			
 			// Si l'avatar est un emoji (pas une image avec chemin)


### PR DESCRIPTION
## Résumé
- Ajout d'une fonction `deleteUserSessions` dans `db.ts` pour supprimer toutes les sessions d'un utilisateur
- Invalidation automatique des autres sessions lors d'un changement de mot de passe
- La session courante est conservée pour ne pas déconnecter l'utilisateur

## Problème
Lorsqu'un utilisateur changeait son mot de passe dans les réglages, ses sessions existantes (sur d'autres appareils ou navigateurs) restaient actives. Cela signifie qu'un attaquant ayant accès à une session volée pouvait continuer à l'utiliser même après un changement de mot de passe — ce qui annule l'intérêt même de changer son mot de passe en cas de compromission.

## Solution
1. **Nouvelle fonction `deleteUserSessions(userId, exceptSessionId?)`** dans `src/lib/server/db.ts` : supprime toutes les sessions d'un utilisateur, avec possibilité d'en exclure une (la session courante).
2. **Appel après le changement de mot de passe** dans `src/routes/settings/+page.server.ts` : après `updateUserPassword`, on récupère le cookie de session courant et on invalide toutes les autres sessions.

L'utilisateur qui change son mot de passe reste connecté (confort UX), mais toutes ses autres sessions sont révoquées (sécurité).

## Test plan
- [ ] Changer son mot de passe dans les réglages et vérifier qu'on reste connecté
- [ ] Vérifier qu'une session ouverte dans un autre navigateur est bien déconnectée après le changement
- [ ] Vérifier que ne pas changer le mot de passe (modification d'avatar uniquement) ne touche pas aux sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)