### PR TITLE
chore: migrate to Semantic Versioning 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,35 @@
 
 ---
 
-## v2.7.1 (2026-04-02)
+## v0.27.0 (2026-04-02) - Migration Semantic Versioning
+
+### 🔄 Changement majeur
+
+#### Adoption de Semantic Versioning
+- **Migration** : Passage du système de versioning arbitraire 2.x à SemVer 0.x
+- **Raison** : Mieux refléter le statut beta du projet
+- **Impact** : Pas de changement fonctionnel, uniquement sémantique
+
+#### Nouvelle structure des versions
+- **0.x.y** : Phase beta, API susceptible de changer
+- Prochaines versions : 0.28.0, 0.29.0, puis 1.0.0 quand l'API sera stabilisée
+
+#### Documentation
+- Ajout section "Versioning" dans README.md
+- Ajout section "Branches" documentant `main` et `develop`
+- Mise à jour du badge de version (2.7.1 → 0.27.0)
+
+### 📚 Notes
+
+Les versions 2.x (de v2.0.0 à v2.7.1) représentent l'historique de développement avant l'adoption officielle de Semantic Versioning. Elles sont conservées dans ce changelog pour référence mais ne suivaient pas la logique SemVer.
+
+---
+
+## Historique des versions (pré-SemVer)
+
+Les versions suivantes ont été développées selon une numérotation arbitraire avant l'adoption de Semantic Versioning le 2026-04-02.
+
+### v2.7.1 (2026-04-02)
 
 ### ✨ Nouvelles fonctionnalités
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![Status](https://img.shields.io/badge/Status-Beta-orange?style=for-the-badge)
 ![License](https://img.shields.io/badge/License-AGPL--3.0-blue?style=for-the-badge)
-![Version](https://img.shields.io/badge/Version-2.7.1-blue?style=for-the-badge)
+![Version](https://img.shields.io/badge/Version-0.27.0-blue?style=for-the-badge)
 
 </div>
 
@@ -29,6 +29,22 @@
 ## Description
 
 Maté Club est une application web PWA permettant à un groupe d'amis d'enregistrer et partager des capsules audio quotidiennes. Chaque membre peut enregistrer des messages vocaux jusqu'à 3 minutes, avec possibilité d'ajouter une miniature image et un lien URL.
+
+## Versioning
+
+Ce projet suit [Semantic Versioning](https://semver.org/lang/fr/).
+
+⚠️ **Changement majeur de versioning (2026-04-02)** : Nous sommes passés du système arbitraire 2.x à un versioning SemVer 0.x pour mieux refléter le statut beta du projet.
+
+- **Versions 2.x** (précédentes) : Numérotation historique avant adoption de SemVer (mars-avril 2026)
+- **Versions 0.x** (actuelles et futures) : Phase beta, API non stabilisée
+
+## Branches
+
+- **`main`** : Version stable actuelle (production) - Toujours déployable
+- **`develop`** : Branche de développement, intégration des futures fonctionnalités
+
+Les contributions doivent passer par des Pull Requests sur `develop`. La branche `main` est protégée et ne reçoit que des merges depuis `develop` ou des hotfixes critiques.
 
 ## Fonctionnalités
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mateclub",
-  "version": "2.7.1",
+  "version": "0.27.0",
   "type": "module",
   "scripts": {
     "dev": "vite dev --host",


### PR DESCRIPTION
## Summary

Migration complète du système de versioning arbitraire 2.x vers Semantic Versioning 0.x.

### Changements

- **package.json**: version 2.7.1 → 0.27.0
- **README.md**: 
  - Badge version mis à jour (2.7.1 → 0.27.0)
  - Nouvelle section "Versioning" expliquant la migration 2.x → 0.x
  - Nouvelle section "Branches" documentant le workflow main/develop
- **CHANGELOG.md**:
  - Ajout entrée v0.27.0 expliquant la migration SemVer
  - Ajout section "Historique des versions (pré-SemVer)" pour les versions 2.x

### Nouvelle structure

- **main**: Version stable actuelle (0.27.0)
- **develop**: Branche de développement futures fonctionnalités
- **Versioning**: SemVer 0.x (phase beta, API non stabilisée)

### Tags

⚠️ Cette PR doit être mergée AVANT de créer le tag v0.27.0

### Notes

Les versions 2.x (v2.0.0 à v2.7.1) restent dans l'historique Git comme versions pré-SemVer.