### PR TITLE
docs: sync main with develop for v0.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ---
 
+## v0.35.1 (2026-05-08) - Visibilite GitHub du changelog
+
+### 📚 Documentation
+
+- **README clarifie sur GitHub** : ajout d'un bloc visible en haut de la page d'accueil du depot avec des liens directs vers la derniere release, le `CHANGELOG.md` complet et la branche `develop`
+- **Version badge mise a jour** : le badge de version du README suit maintenant `0.35.1`
+- **Release documentaire** : cette version sert a rendre les mises a jour recentes beaucoup plus visibles depuis la homepage GitHub du projet
+
+### 🔀 Synchronisation
+
+- **Base de release preparee** : `develop` et `fix` doivent rester alignes sur cette version documentaire avant la resynchronisation de `main`
+
 ## v0.35.0 (2026-05-07) - Notifications push quotidiennes
 
 ### ✨ Nouvelles fonctionnalités

--- a/README.md
+++ b/README.md
@@ -6,13 +6,18 @@
 
 ![Status](https://img.shields.io/badge/Status-Beta-orange?style=for-the-badge)
 ![License](https://img.shields.io/badge/License-AGPL--3.0-blue?style=for-the-badge)
-![Version](https://img.shields.io/badge/Version-0.35.0-blue?style=for-the-badge)
+![Version](https://img.shields.io/badge/Version-0.35.1-blue?style=for-the-badge)
 
 </div>
 
 ✨ **Ce projet est une expérimentation de *vibe coding* de Guillaume Vendé, créateur du podcast [Tech Café](https://techcafe.fr)** ✨
 
 🤝 **Soutenez-moi sur [patreon.com/techcafe](https://patreon.com/techcafe) : le premier niveau d'abonnement est gratuit !**
+
+📌 **Derniere version stable et documentation :**
+- [Derniere release GitHub](https://github.com/guillaumevende/mateclub/releases/latest)
+- [Journal des modifications complet](./CHANGELOG.md)
+- [Branche `develop` (developpements en cours)](https://github.com/guillaumevende/mateclub/tree/develop)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mateclub",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mateclub",
-      "version": "0.35.0",
+      "version": "0.35.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@khmyznikov/pwa-install": "^0.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mateclub",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "type": "module",
   "scripts": {
     "dev": "vite dev --host",


### PR DESCRIPTION
Summary:\n- sync main with develop for documentation release v0.35.1\n- expose direct links to latest release and full changelog from the GitHub homepage\n- align README, CHANGELOG and version metadata on the default branch\n\nTesting:\n- npm test